### PR TITLE
--with-odbc-manager=odbc compilation with clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,7 @@ CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 
 if test -n "${ODBC_CONFIG}"; then
   RODBC_CPPFLAGS=`odbc_config --cflags`
+  RODBC_CPPFLAGS="-I. ${RODBC_CPPFLAGS}"
 fi
 CPPFLAGS="${CPPFLAGS} ${RODBC_CPPFLAGS}"
 


### PR DESCRIPTION
Having `$ODBC_CONFIG` set i.e. specifying `--with-odbc-manager=odbc` causes a compilation issue (below) when trying to find the auto tools built `config.h`.

```
clang -I/Library/Frameworks/R.framework/Resources/include -DNDEBUG -DHAVE_UNISTD_H -DHAVE_PWD_H -DHAVE_SYS_TYPES_H -DHAVE_LONG_LONG -DSIZEOF_LONG_INT=8 -I/opt/local/include  -I/usr/local/include -I/usr/local/include/freetype2 -I/opt/X11/include    -fPIC  -Wall -mtune=core2 -g -O2  -c RODBC.c -o RODBC.o
RODBC.c:23:10: error: 'config.h' file not found with <angled> include; use "quotes" instead
#include <config.h>
         ^~~~~~~~~~
         "config.h"
```

This is a result of [line 61](https://github.com/cran/RODBC/blob/master/configure.ac#L61) not including the current directory (`-I.`) as lines [24](https://github.com/cran/RODBC/blob/master/configure.ac#L24) and [27](https://github.com/cran/RODBC/blob/master/configure.ac#L27) do.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cran/rodbc/2)

<!-- Reviewable:end -->
